### PR TITLE
Place SNSTopicName In Error

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,9 @@
 package grim
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // Copyright 2015 MediaMath <http://www.mediamath.com>.  All rights reserved.
 // Use of this source code is governed by a BSD-style
@@ -249,9 +252,14 @@ func TestLocalEffectiveConfigDoesntOverwriteGlobals(t *testing.T) {
 }
 
 func TestValidateLocalEffectiveConfig(t *testing.T) {
-	errs := localConfig{local: configMap{"SNSTopicName": "foo.go"}}.errors()
+	snsTopicName := "foo.go"
+	errs := localConfig{local: configMap{"SNSTopicName": snsTopicName}}.errors()
 	if len(errs) == 0 {
 		t.Errorf("validated with period in name")
+	}
+
+	if !strings.Contains(errs[0].Error(), "[ " + snsTopicName + " ]") {
+		t.Errorf("error message should mention SNSTopicName %v", errs[0].Error())
 	}
 }
 

--- a/localconfig.go
+++ b/localconfig.go
@@ -69,7 +69,7 @@ func (lc localConfig) errors() (errs []error) {
 	if snsTopicName == "" {
 		errs = append(errs, fmt.Errorf("Must have a Sns topic name!"))
 	} else if strings.Contains(snsTopicName, ".") {
-		errs = append(errs, fmt.Errorf("Cannot have . in sns topic name.  Default topic names can be set in the build config file using the SnsTopicName parameter."))
+		errs = append(errs, fmt.Errorf("Cannot have . in sns topic name [ %s ].  Default topic names can be set in the build config file using the SnsTopicName parameter.", snsTopicName))
 	}
 	return
 }


### PR DESCRIPTION
fixes #83

If a local topic name contains something like "auth.go", an error
will be thrown with the problematic snstopic name.