### PR TITLE
Make logs have timestamps

### DIFF
--- a/grimd/main.go
+++ b/grimd/main.go
@@ -35,6 +35,10 @@ var (
 )
 
 func main() {
+	log.SetOutput(os.Stdout)
+	log.SetPrefix(fmt.Sprintf("grimd-%v ", version))
+	log.SetFlags(log.Ldate | log.Ltime)
+
 	app := cli.NewApp()
 
 	app.Action = grimd


### PR DESCRIPTION
We should probably overhaul our logging as some places are using the golang std logger and other places are injecting one, but I'm not doing that yet.  This just makes the injected one and the std logger have the same format.

I also added timestamps to the build status file that gets put into the log directory.

Fixes #120